### PR TITLE
User Entity nickname 속성 추가, 회원가입 RegisterDto nickname 추가, AuthService…

### DIFF
--- a/src/main/java/com/example/recipeapp/domain/auth/controller/dto/request/RegisterRequestDto.java
+++ b/src/main/java/com/example/recipeapp/domain/auth/controller/dto/request/RegisterRequestDto.java
@@ -10,7 +10,11 @@ import lombok.Getter;
 public class RegisterRequestDto {
 
     @NotBlank
-    @Pattern(regexp = "^[가-힣a-zA-Z]{4,20}$", message = "4-20자의 한글 또는 영문을 입력해주세요.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,10}$", message = "닉네임은 2-10자로 한글, 영어, 숫자로 조합되어야 합니다.")
+    private String nickname;
+
+    @NotBlank
+    @Pattern(regexp = "^[가-힣a-zA-Z]{2,10}$", message = "이름은 2-10자의 한글 또는 영문을 입력해주세요.")
     private String username;
 
     @NotBlank
@@ -18,14 +22,15 @@ public class RegisterRequestDto {
     private String email;
 
     @NotBlank
-    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "비밀번호는 8-15자로 영문과 숫자를 포함해야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "비밀번호는 8-15자로 영문과 숫자로 조합되어야 합니다.")
     private String password;
 
-    public static SaveUserDto toSaveUserDto(RegisterRequestDto requestDto) {
+    public static SaveUserDto toSaveUserDto(RegisterRequestDto registerRequestDto) {
         return SaveUserDto.builder()
-                          .username(requestDto.getUsername())
-                          .email(requestDto.getEmail())
-                          .password(requestDto.getPassword())
+                          .nickname(registerRequestDto.getNickname())
+                          .username(registerRequestDto.getUsername())
+                          .email(registerRequestDto.getEmail())
+                          .password(registerRequestDto.getPassword())
                           .build();
     }
 

--- a/src/main/java/com/example/recipeapp/domain/auth/controller/dto/response/RegisterResponseDto.java
+++ b/src/main/java/com/example/recipeapp/domain/auth/controller/dto/response/RegisterResponseDto.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class RegisterResponseDto {
 
     private Long id;
+    private String nickname;
     private String username;
     private String email;
     private String role;
@@ -18,6 +19,7 @@ public class RegisterResponseDto {
     public static RegisterResponseDto from(User user) {
         return RegisterResponseDto.builder()
                                   .id(user.getId())
+                                  .nickname(user.getNickname())
                                   .username(user.getUsername())
                                   .email(user.getEmail())
                                   .role(user.getRole().getRole())

--- a/src/main/java/com/example/recipeapp/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/recipeapp/domain/auth/service/AuthService.java
@@ -21,9 +21,10 @@ public class AuthService {
 
     public RegisterResponseDto register(SaveUserDto saveUserDto) {
 
-        checkDuplicatesOrThrow(saveUserDto.getEmail());
+        checkDuplicatesOrThrow(saveUserDto.getNickname(), saveUserDto.getEmail());
 
         User user = User.builder()
+                        .nickname(saveUserDto.getNickname())
                         .username(saveUserDto.getUsername())
                         .email(saveUserDto.getEmail())
                         .password(passwordEncoder.encode(saveUserDto.getPassword()))
@@ -34,7 +35,12 @@ public class AuthService {
         return RegisterResponseDto.from(savedUser);
     }
 
-    private void checkDuplicatesOrThrow(String email) {
+    private void checkDuplicatesOrThrow(String nickname, String email) {
+
+        boolean hasDuplicateNickname = userRepository.existsByNickname(nickname);
+        if (hasDuplicateNickname) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
 
         boolean hasDuplicateEmail = userRepository.existsByEmail(email);
         if (hasDuplicateEmail) {

--- a/src/main/java/com/example/recipeapp/domain/auth/service/dto/request/SaveUserDto.java
+++ b/src/main/java/com/example/recipeapp/domain/auth/service/dto/request/SaveUserDto.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Getter
 public class SaveUserDto {
 
+    private String nickname;
+
     private String username;
 
     private String email;

--- a/src/main/java/com/example/recipeapp/domain/user/domain/model/User.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/model/User.java
@@ -18,7 +18,10 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(nullable = false, unique = true, length = 10)
+    private String nickname;
+
+    @Column(nullable = false,length = 10)
     private String username;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/example/recipeapp/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/recipeapp/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
     // 유저 관련 에러 정의
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 


### PR DESCRIPTION
… nickname 중복 검증 로직 추가

## 📌 개요
회원가입 API에서 Request로 유저의 이름, 닉네임(아이디), 이메일, 비밀번호를 받도록 변경

## ✅ 작업 사항
- [x] UserEntity nickname 속성 추가, 
- [x] 회원가입 RegisterDto nickname 추가
- [x] AuthService nickname 중복 검증 로직 추가

## 🔍 리뷰 요청 포인트
- 요청, 응답Dto에서 nickname이 빠진 부분이 있는지 확인부탁드립니다. 

## 💬 기타 사항
- 관련 이슈: #22 

---