### PR TITLE
[feat] 비밀번호 수정API

### DIFF
--- a/src/main/java/com/example/recipeapp/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/recipeapp/domain/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.example.recipeapp.domain.user.controller;
 
-import com.example.recipeapp.domain.user.controller.dto.PasswordChangeRequest;
+import com.example.recipeapp.domain.auth.domain.model.AuthUser;
+import com.example.recipeapp.domain.user.controller.dto.request.PasswordChangeRequestDto;
 import com.example.recipeapp.domain.user.controller.dto.response.UserResponseDto;
 import com.example.recipeapp.domain.user.service.UserService;
+import com.example.recipeapp.domain.user.service.dto.ChangePasswordDto;
 import com.example.recipeapp.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +14,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -33,5 +31,16 @@ public class UserController {
         Page<UserResponseDto> users = userService.getAllUsers(pageable);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("회원 전체 조회에 성공했습니다.", users));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @Valid @RequestBody PasswordChangeRequestDto request,
+            @AuthenticationPrincipal AuthUser authuser){
+
+        ChangePasswordDto change = PasswordChangeRequestDto.toChangePasswordDto(request);
+        userService.changePassword(authuser, change);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("비밀번호 변경에 성공했습니다.", null));
     }
 }

--- a/src/main/java/com/example/recipeapp/domain/user/controller/dto/request/PasswordChangeRequestDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/controller/dto/request/PasswordChangeRequestDto.java
@@ -1,0 +1,30 @@
+package com.example.recipeapp.domain.user.controller.dto.request;
+
+import com.example.recipeapp.domain.user.service.dto.ChangePasswordDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class PasswordChangeRequestDto {
+
+    @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "비밀번호는 8-15자로 영문과 숫자로 조합되어야 합니다.")
+    private String currentPassword;
+
+    @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "비밀번호는 8-15자로 영문과 숫자로 조합되어야 합니다.")
+    private String newPassword;
+
+    @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9]{8,15}$", message = "비밀번호는 8-15자로 영문과 숫자로 조합되어야 합니다.")
+    private String confirmPassword;
+
+    public static ChangePasswordDto toChangePasswordDto(PasswordChangeRequestDto request){
+        return ChangePasswordDto.builder()
+                                .currentPassword(request.getCurrentPassword())
+                                .newPassword(request.getNewPassword())
+                                .confirmPassword(request.getConfirmPassword())
+                                .build();
+    }
+}

--- a/src/main/java/com/example/recipeapp/domain/user/domain/model/User.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/model/User.java
@@ -47,4 +47,8 @@ public class User extends BaseTimeEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
+    public void changePassword(String password){
+        this.password = password;
+    }
+
 }

--- a/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Page<User> findAllByIsDeletedFalse(Pageable pageable);
 
+    Optional<User> findByIdAndIsDeletedFalse(Long userId);
+
 }

--- a/src/main/java/com/example/recipeapp/domain/user/service/UserService.java
+++ b/src/main/java/com/example/recipeapp/domain/user/service/UserService.java
@@ -1,13 +1,21 @@
 package com.example.recipeapp.domain.user.service;
 
+import com.example.recipeapp.domain.auth.domain.model.AuthUser;
+import com.example.recipeapp.domain.auth.service.AuthService;
+import com.example.recipeapp.domain.user.controller.dto.request.PasswordChangeRequestDto;
 import com.example.recipeapp.domain.user.controller.dto.response.UserResponseDto;
 import com.example.recipeapp.domain.user.domain.model.User;
 import com.example.recipeapp.domain.user.domain.repository.UserRepository;
+import com.example.recipeapp.domain.user.service.dto.ChangePasswordDto;
+import com.example.recipeapp.global.exception.CustomException;
+import com.example.recipeapp.global.exception.ErrorCode;
+import com.example.recipeapp.global.security.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -16,7 +24,9 @@ import java.util.List;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
+    @Transactional(readOnly = true)
     public Page<UserResponseDto> getAllUsers(Pageable pageable) {
 
         Page<User> users = userRepository.findAllByIsDeletedFalse(pageable);
@@ -28,4 +38,32 @@ public class UserService {
         return new PageImpl<>(userResponseDtos, pageable, users.getTotalElements());
     }
 
+    @Transactional
+    public void changePassword(AuthUser authuser, ChangePasswordDto request) {
+        User user = findByIdAndIsDeletedFalseOrThrow(authuser.getId());
+
+        // 현재 비밀번호가 일치하지 않는 경우
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // 새 비밀번호가 기존 비밀번호와 같은 경우
+        if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())){
+            throw new CustomException(ErrorCode.NEW_PASSWORD_SAME);
+        }
+
+        // 새 비밀번호와 비밀번호 확인이 일치하지 않는 경우
+        if (!request.getNewPassword().equals(request.getConfirmPassword())){
+            throw new CustomException((ErrorCode.PASSWORD_CONFIRM_MISMATCH));
+        }
+
+        String newPassword = passwordEncoder.encode(request.getNewPassword());
+
+        user.changePassword(newPassword);
+    }
+
+    public User findByIdAndIsDeletedFalseOrThrow(Long userId) {
+        return userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/example/recipeapp/domain/user/service/dto/ChangePasswordDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/service/dto/ChangePasswordDto.java
@@ -1,0 +1,16 @@
+package com.example.recipeapp.domain.user.service.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChangePasswordDto {
+
+    private String currentPassword;
+
+    private String newPassword;
+
+    private String confirmPassword;
+
+}

--- a/src/main/java/com/example/recipeapp/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/recipeapp/global/exception/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    NEW_PASSWORD_SAME(HttpStatus.BAD_REQUEST, "기존 비밀번호와 다르게 설정해 주세요"),
+
 
     // 게시글 관련 에러 정의
     TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다.");


### PR DESCRIPTION
## 📌 개요
사용자 비밀번호 변경 기능 구현 (PATCH /api/users/me)

## ✅ 작업 사항
- [x] Controller DTO와 Service DTO를 분리하여 계층별 역할 분담
- [x] UserService.changePassword() 구현 (비밀번호 검증 및 인코딩 처리 포함)
- [x] User 엔티티에 changePassword() 메서드 추가

## 🔍 리뷰 요청 포인트


## 💬 기타 사항
- 관련 이슈: #30 
- 참고 자료: [링크]

---