### PR TITLE
feat : 회원탈퇴 api 구현

### DIFF
--- a/src/main/java/com/example/recipeapp/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/recipeapp/domain/auth/controller/AuthController.java
@@ -2,7 +2,10 @@ package com.example.recipeapp.domain.auth.controller;
 
 import com.example.recipeapp.domain.auth.controller.dto.request.LoginRequestDto;
 import com.example.recipeapp.domain.auth.controller.dto.request.RegisterRequestDto;
+import com.example.recipeapp.domain.auth.controller.dto.request.WithdrawRequestDto;
 import com.example.recipeapp.domain.auth.controller.dto.response.LoginResponseDto;
+import com.example.recipeapp.domain.auth.domain.model.AuthUser;
+import com.example.recipeapp.domain.auth.service.dto.request.DeleteUserDto;
 import com.example.recipeapp.domain.auth.service.dto.request.SaveUserDto;
 import com.example.recipeapp.domain.auth.controller.dto.response.RegisterResponseDto;
 import com.example.recipeapp.domain.auth.service.AuthService;
@@ -11,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,5 +47,23 @@ public class AuthController {
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @PostMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+        @AuthenticationPrincipal AuthUser authUser,
+        @RequestBody @Valid WithdrawRequestDto withdrawRequestDto
+    ) {
+
+        DeleteUserDto deleteUserDto = new DeleteUserDto(
+            authUser.getId(),
+            withdrawRequestDto.getPassword()
+        );
+        authService.withdraw(deleteUserDto);
+        ApiResponse<Void> response = ApiResponse.success("회원 탈퇴 처리되었습니다.", null);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+
 
 }

--- a/src/main/java/com/example/recipeapp/domain/auth/controller/dto/request/WithdrawRequestDto.java
+++ b/src/main/java/com/example/recipeapp/domain/auth/controller/dto/request/WithdrawRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.recipeapp.domain.auth.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class WithdrawRequestDto {
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+}

--- a/src/main/java/com/example/recipeapp/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/recipeapp/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.example.recipeapp.domain.auth.service;
 
 import com.example.recipeapp.domain.auth.controller.dto.request.LoginRequestDto;
 import com.example.recipeapp.domain.auth.controller.dto.response.LoginResponseDto;
+import com.example.recipeapp.domain.auth.service.dto.request.DeleteUserDto;
 import com.example.recipeapp.domain.auth.service.dto.request.SaveUserDto;
 import com.example.recipeapp.domain.auth.controller.dto.response.RegisterResponseDto;
 import com.example.recipeapp.domain.user.domain.model.User;
@@ -58,6 +59,24 @@ public class AuthService {
 
         return new LoginResponseDto(token);
     }
+
+    public void withdraw(DeleteUserDto deleteUserDto) {
+
+        User withdrawUser = userRepository.findById(deleteUserDto.getUserId())
+                                  .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (withdrawUser.getIsDeleted()) {
+            throw new CustomException(ErrorCode.ALREADY_WITHDRAW_USER);
+        }
+
+        if (!passwordEncoder.matches(deleteUserDto.getPassword(), withdrawUser.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        withdrawUser.delete();
+    }
+
+
 
     private void checkDuplicatesOrThrow(String nickname, String email) {
 

--- a/src/main/java/com/example/recipeapp/domain/auth/service/dto/request/DeleteUserDto.java
+++ b/src/main/java/com/example/recipeapp/domain/auth/service/dto/request/DeleteUserDto.java
@@ -1,0 +1,18 @@
+package com.example.recipeapp.domain.auth.service.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeleteUserDto {
+
+    private final Long userId;
+    private final String password;
+
+    public DeleteUserDto(Long userId, String password) {
+        this.userId = userId;
+        this.password = password;
+    }
+
+}

--- a/src/main/java/com/example/recipeapp/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/recipeapp/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
     // 유저 관련 에러 정의
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    ALREADY_WITHDRAW_USER(HttpStatus.BAD_REQUEST, "이미 회원탈퇴된 유저입니다."),
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),


### PR DESCRIPTION
## 📌 개요
회원탈퇴 api 구현

## ✅ 작업 사항
- [x] AuthController, AuthService 회원탈퇴 api 구현
- [x] controller layer에서 사용할 WithdrawRequestDto, servicelayer에서 사용할 DeleteUserDto 작성
- [x] ErrorCode ALREADY_WITHDRAW_USER 추가

## 🔍 리뷰 요청 포인트
- 유저 인증정보로 authUser entity사용, dto layer별 분리한 부분 확인부탁드립니다. 

## 💬 기타 사항
- 관련 이슈: #29 

---