### PR TITLE
Issue/34 feat: 레시피 CRUD 구현 및 예외 처리 통일 

### DIFF
--- a/src/main/java/com/example/recipeapp/domain/like/Service/LikeService.java
+++ b/src/main/java/com/example/recipeapp/domain/like/Service/LikeService.java
@@ -1,60 +1,60 @@
-package com.example.recipeapp.domain.like.Service;
-
-import com.example.recipeapp.domain.like.domain.model.entity.Likes;
-import com.example.recipeapp.domain.like.domain.repository.LikeRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-@Service
-@RequiredArgsConstructor
-public class LikeService {
-
-    private final LikeRepository likeRepository;
-    private final RecipeRepository recipeRepository;
-    private final UserRepository userRepository;
-
-
-    //좋아요 등록
-    public void registerLike (Long userId, Long recipeId) {
-
-        User user = getUserById(userId);  //좋아요 누른 사람 ID, (로그인된)요청한 사용자
-        Recipe recipe = getRecipeById(recipeId);  //게시글ID로 실제 DB에 존재하는 레시피게시글 객체를 가져오기
-        //user나 task가 존재하지 않으면, NullPointerException임
-
-        //예외 (중복 좋아요 방지), 나중에 커스텀예외로 분리
-        if (likeRepository.findByUserAndRecipe(user, recipe).isPresent()) {
-            throw new IllegalStateException("이미 좋아요를 누른 게시글입니다.");
-        }
-
-        //좋아요 생성, 저장
-        Likes like = new Likes(user, recipe);
-        likeRepository.save(like);
-
-    }
-
-
-    //좋아요 취소
-    public void cancelLike (Long userId, Long recipeId) {
-
-        User user = getUserById(userId);  //좋아요 누른 사람 ID
-        Recipe recipe = getRecipeById(recipeId);  // 좋아요가 눌린 게시글
-
-        // 이 유저가 이 게시글에 눌렀던 좋아요 엔티티 찾기, 나중에 커스텀예외로 분리
-        Likes like = likeRepository.findByUserAndRecipe(user, recipe)
-                .orElseThrow(() -> new NoSuchElementException("좋아요를 누른 적이 없는 게시글입니다.")); //값이 존재하지 않아 꺼낼 수 없을 때 사용하는 예외클래스
-
-        // 좋아요 삭제
-        likeRepository.delete(like);
-
-    }
-
-
-    //좋아요 수 조회
-    public Long countLikes (Long recipeId) {
-
-        Recipe recipe = getRecipeById(recipeId);  // 게시글 존재 여부 확인
-        return likeRepository.countByPost(recipe);
-
-    }
-
-}
+//package com.example.recipeapp.domain.like.Service;
+//
+//import com.example.recipeapp.domain.like.domain.model.entity.Likes;
+//import com.example.recipeapp.domain.like.domain.repository.LikeRepository;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Service;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class LikeService {
+//
+//    private final LikeRepository likeRepository;
+//    private final RecipeRepository recipeRepository;
+//    private final UserRepository userRepository;
+//
+//
+//    //좋아요 등록
+//    public void registerLike (Long userId, Long recipeId) {
+//
+//        User user = getUserById(userId);  //좋아요 누른 사람 ID, (로그인된)요청한 사용자
+//        Recipe recipe = getRecipeById(recipeId);  //게시글ID로 실제 DB에 존재하는 레시피게시글 객체를 가져오기
+//        //user나 task가 존재하지 않으면, NullPointerException임
+//
+//        //예외 (중복 좋아요 방지), 나중에 커스텀예외로 분리
+//        if (likeRepository.findByUserAndRecipe(user, recipe).isPresent()) {
+//            throw new IllegalStateException("이미 좋아요를 누른 게시글입니다.");
+//        }
+//
+//        //좋아요 생성, 저장
+//        Likes like = new Likes(user, recipe);
+//        likeRepository.save(like);
+//
+//    }
+//
+//
+//    //좋아요 취소
+//    public void cancelLike (Long userId, Long recipeId) {
+//
+//        User user = getUserById(userId);  //좋아요 누른 사람 ID
+//        Recipe recipe = getRecipeById(recipeId);  // 좋아요가 눌린 게시글
+//
+//        // 이 유저가 이 게시글에 눌렀던 좋아요 엔티티 찾기, 나중에 커스텀예외로 분리
+//        Likes like = likeRepository.findByUserAndRecipe(user, recipe)
+//                .orElseThrow(() -> new NoSuchElementException("좋아요를 누른 적이 없는 게시글입니다.")); //값이 존재하지 않아 꺼낼 수 없을 때 사용하는 예외클래스
+//
+//        // 좋아요 삭제
+//        likeRepository.delete(like);
+//
+//    }
+//
+//
+//    //좋아요 수 조회
+//    public Long countLikes (Long recipeId) {
+//
+//        Recipe recipe = getRecipeById(recipeId);  // 게시글 존재 여부 확인
+//        return likeRepository.countByPost(recipe);
+//
+//    }
+//
+//}

--- a/src/main/java/com/example/recipeapp/domain/like/controller/LikeController.java
+++ b/src/main/java/com/example/recipeapp/domain/like/controller/LikeController.java
@@ -1,57 +1,57 @@
-package com.example.recipeapp.domain.like.controller;
-
-import com.example.recipeapp.domain.like.Service.LikeService;
-import com.example.recipeapp.domain.like.controller.dto.LikeResponseDto;
-import com.example.recipeapp.global.response.ApiResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-@RestController
-@RequiredArgsConstructor
-public class LikeController {
-
-    private final LikeService likeService;
-
-    //좋아요 등록
-    @PostMapping
-    public ResponseEntity<ApiResponse<LikeResponseDto>> registerLike(
-            @RequestParam Long recipeId,
-            @AuthenticationPrincipal User user) {
-
-        LikeResponseDto response = likeService.registerLike(user.getId(), recipeId);
-        return ResponseEntity.ok(ApiResponse.success("좋아요 등록 완료", response));
-    }
-
-    // 좋아요 취소
-    @DeleteMapping
-    public ResponseEntity<ApiResponse<LikeResponseDto>> cancelLike(
-            @RequestParam Long recipeId,
-            @AuthenticationPrincipal User user) {
-
-        LikeResponseDto response = likeService.cancelLike(user.getId(), recipeId);
-        return ResponseEntity.ok(ApiResponse.success("좋아요 취소 완료", response));
-    }
-
-    // 좋아요 개수 조회 (익명 가능)
-    @GetMapping("/count")
-    public ResponseEntity<ApiResponse<LikeCountResponseDto>> countLikes(
-            @RequestParam Long recipeId) {
-
-        LikeCountResponseDto response = likeService.countLikes(recipeId);
-        return ResponseEntity.ok(ApiResponse.success("좋아요 개수 조회 성공", response));
-    }
-
-    // 좋아요 여부 확인 (로그인 사용자)
-    @GetMapping("/status")
-    public ResponseEntity<ApiResponse<LikeStatusResponseDto>> checkLiked(
-            @RequestParam Long recipeId,
-            @AuthenticationPrincipal User user) {
-
-        LikeStatusResponseDto response = likeService.isLiked(user.getId(), recipeId);
-        return ResponseEntity.ok(ApiResponse.success("좋아요 여부 조회 성공", response));
-    }
-
-
-}
+//package com.example.recipeapp.domain.like.controller;
+//
+//import com.example.recipeapp.domain.like.Service.LikeService;
+//import com.example.recipeapp.domain.like.controller.dto.LikeResponseDto;
+//import com.example.recipeapp.global.response.ApiResponse;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+//import org.springframework.web.bind.annotation.*;
+//
+//@RestController
+//@RequiredArgsConstructor
+//public class LikeController {
+//
+//    private final LikeService likeService;
+//
+//    //좋아요 등록
+//    @PostMapping
+//    public ResponseEntity<ApiResponse<LikeResponseDto>> registerLike(
+//            @RequestParam Long recipeId,
+//            @AuthenticationPrincipal User user) {
+//
+//        LikeResponseDto response = likeService.registerLike(user.getId(), recipeId);
+//        return ResponseEntity.ok(ApiResponse.success("좋아요 등록 완료", response));
+//    }
+//
+//    // 좋아요 취소
+//    @DeleteMapping
+//    public ResponseEntity<ApiResponse<LikeResponseDto>> cancelLike(
+//            @RequestParam Long recipeId,
+//            @AuthenticationPrincipal User user) {
+//
+//        LikeResponseDto response = likeService.cancelLike(user.getId(), recipeId);
+//        return ResponseEntity.ok(ApiResponse.success("좋아요 취소 완료", response));
+//    }
+//
+//    // 좋아요 개수 조회 (익명 가능)
+//    @GetMapping("/count")
+//    public ResponseEntity<ApiResponse<LikeCountResponseDto>> countLikes(
+//            @RequestParam Long recipeId) {
+//
+//        LikeCountResponseDto response = likeService.countLikes(recipeId);
+//        return ResponseEntity.ok(ApiResponse.success("좋아요 개수 조회 성공", response));
+//    }
+//
+//    // 좋아요 여부 확인 (로그인 사용자)
+//    @GetMapping("/status")
+//    public ResponseEntity<ApiResponse<LikeStatusResponseDto>> checkLiked(
+//            @RequestParam Long recipeId,
+//            @AuthenticationPrincipal User user) {
+//
+//        LikeStatusResponseDto response = likeService.isLiked(user.getId(), recipeId);
+//        return ResponseEntity.ok(ApiResponse.success("좋아요 여부 조회 성공", response));
+//    }
+//
+//
+//}

--- a/src/main/java/com/example/recipeapp/domain/like/domain/model/entity/Likes.java
+++ b/src/main/java/com/example/recipeapp/domain/like/domain/model/entity/Likes.java
@@ -1,24 +1,24 @@
-package com.example.recipeapp.domain.like.domain.model.entity;
-
-import jakarta.persistence.*;
-import lombok.*;
-
-import java.time.LocalDateTime;
-
-@Entity
-@Table(name = "likes")
-public class Likes {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User user; // 좋아요 누른 사람
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Recipe recipe; // 좋아요 대상 게시글
-
-    private LocalDateTime createdAt;
-
-}
+//package com.example.recipeapp.domain.like.domain.model.entity;
+//
+//import jakarta.persistence.*;
+//import lombok.*;
+//
+//import java.time.LocalDateTime;
+//
+//@Entity
+//@Table(name = "likes")
+//public class Likes {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    private User user; // 좋아요 누른 사람
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    private Recipe recipe; // 좋아요 대상 게시글
+//
+//    private LocalDateTime createdAt;
+//
+//}

--- a/src/main/java/com/example/recipeapp/domain/like/domain/repository/LikeRepository.java
+++ b/src/main/java/com/example/recipeapp/domain/like/domain/repository/LikeRepository.java
@@ -1,20 +1,20 @@
-package com.example.recipeapp.domain.like.domain.repository;
-
-import com.example.recipeapp.domain.like.domain.model.entity.Likes;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
-
-public interface LikeRepository extends JpaRepository<Likes, Long> {
-
-    //특정 사용자가 특정 게시글(Post)에 대해 좋아요를 눌렀는지 조회 (중복 등록 확인, 취소 시 존재 여부 확인)
-    Optional<Likes> findByUserAndRecipe(User user, Recipe recipe);
-
-    //특정 게시글 1개에 대한 총 좋아요 수 (Likes 테이블에서 post 컬럼이 특정 값인 row들의 개수)
-    //SELECT COUNT(*) FROM likes WHERE post_id = ?;
-    long countByRecipe(Recipe recipe);
-
-    //좋아요 삭제
-    void deleteByUserAndRecipe(User user, Recipe recipe);
-
-}
+//package com.example.recipeapp.domain.like.domain.repository;
+//
+//import com.example.recipeapp.domain.like.domain.model.entity.Likes;
+//import org.springframework.data.jpa.repository.JpaRepository;
+//
+//import java.util.Optional;
+//
+//public interface LikeRepository extends JpaRepository<Likes, Long> {
+//
+//    //특정 사용자가 특정 게시글(Post)에 대해 좋아요를 눌렀는지 조회 (중복 등록 확인, 취소 시 존재 여부 확인)
+//    Optional<Likes> findByUserAndRecipe(User user, Recipe recipe);
+//
+//    //특정 게시글 1개에 대한 총 좋아요 수 (Likes 테이블에서 post 컬럼이 특정 값인 row들의 개수)
+//    //SELECT COUNT(*) FROM likes WHERE post_id = ?;
+//    long countByRecipe(Recipe recipe);
+//
+//    //좋아요 삭제
+//    void deleteByUserAndRecipe(User user, Recipe recipe);
+//
+//}

--- a/src/main/java/com/example/recipeapp/domain/recipes/controller/RecipeController.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/controller/RecipeController.java
@@ -1,5 +1,7 @@
 package com.example.recipeapp.domain.recipes.controller;
 
+import com.example.recipeapp.global.exception.CustomException;
+import com.example.recipeapp.global.exception.ErrorCode;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.example.recipeapp.domain.auth.domain.model.AuthUser;
 import com.example.recipeapp.domain.recipes.controller.dto.RecipeCreateRequest;
@@ -25,7 +27,7 @@ public class RecipeController {
     @PostMapping
     public ResponseEntity<Long> createRecipe(@RequestBody RecipeCreateRequest request, @AuthenticationPrincipal AuthUser authUser) {
         User user = userRepository.findById(authUser.getId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Long recipeId = recipeService.createRecipe(request, user);
         return ResponseEntity.ok(recipeId);

--- a/src/main/java/com/example/recipeapp/domain/recipes/controller/RecipeController.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/controller/RecipeController.java
@@ -1,0 +1,59 @@
+package com.example.recipeapp.domain.recipes.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.example.recipeapp.domain.auth.domain.model.AuthUser;
+import com.example.recipeapp.domain.recipes.controller.dto.RecipeCreateRequest;
+import com.example.recipeapp.domain.recipes.controller.dto.RecipeResponse;
+import com.example.recipeapp.domain.recipes.controller.dto.RecipeUpdateRequest;
+import com.example.recipeapp.domain.recipes.service.RecipeService;
+import com.example.recipeapp.domain.user.domain.model.User;
+import com.example.recipeapp.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/recipes")
+@RequiredArgsConstructor
+public class RecipeController {
+
+    private final RecipeService recipeService;
+    private final UserRepository userRepository;
+    // 1. 레시피 작성
+    @PostMapping
+    public ResponseEntity<Long> createRecipe(@RequestBody RecipeCreateRequest request, @AuthenticationPrincipal AuthUser authUser) {
+        User user = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+        Long recipeId = recipeService.createRecipe(request, user);
+        return ResponseEntity.ok(recipeId);
+    }
+
+    // 2. 전체 레시피 조회
+    @GetMapping
+    public ResponseEntity<List<RecipeResponse>> getAllRecipes() {
+        return ResponseEntity.ok(recipeService.getAllRecipes());
+    }
+
+    // 3. 단일 레시피 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<RecipeResponse> getRecipe(@PathVariable Long id) {
+        return ResponseEntity.ok(recipeService.getRecipeById(id));
+    }
+
+    // 4. 레시피 수정
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateRecipe(@PathVariable Long id, @RequestBody RecipeUpdateRequest request) {
+        recipeService.updateRecipe(id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 5. 레시피 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteRecipe(@PathVariable Long id) {
+        recipeService.deleteRecipe(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/recipeapp/domain/recipes/controller/dto/RecipeCreateRequest.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/controller/dto/RecipeCreateRequest.java
@@ -1,0 +1,11 @@
+package com.example.recipeapp.domain.recipes.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RecipeCreateRequest {
+    private String title;
+    private String content;
+    private String category;
+    private String imageUrl;
+}

--- a/src/main/java/com/example/recipeapp/domain/recipes/controller/dto/RecipeResponse.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/controller/dto/RecipeResponse.java
@@ -1,0 +1,23 @@
+package com.example.recipeapp.domain.recipes.controller.dto;
+import com.example.recipeapp.domain.recipes.domain.model.Recipe;
+
+import lombok.Getter;
+
+@Getter
+public class RecipeResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private String category;
+    private String imageUrl;
+    private int likes;
+
+    public RecipeResponse(Recipe recipe) {
+        this.id = recipe.getId();
+        this.title = recipe.getTitle();
+        this.content = recipe.getContent();
+        this.category = recipe.getCategory();
+        this.imageUrl = recipe.getImageUrl();
+        this.likes = recipe.getLikes();
+    }
+}

--- a/src/main/java/com/example/recipeapp/domain/recipes/controller/dto/RecipeUpdateRequest.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/controller/dto/RecipeUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.example.recipeapp.domain.recipes.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RecipeUpdateRequest {
+    private String title;
+    private String content;
+    private String category;
+    private String imageUrl;
+}

--- a/src/main/java/com/example/recipeapp/domain/recipes/domain/repository/RecipeRepository.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/domain/repository/RecipeRepository.java
@@ -1,0 +1,7 @@
+package com.example.recipeapp.domain.recipes.domain.repository;
+
+import com.example.recipeapp.domain.recipes.domain.model.Recipe;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+}

--- a/src/main/java/com/example/recipeapp/domain/recipes/service/RecipeService.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/service/RecipeService.java
@@ -1,0 +1,67 @@
+package com.example.recipeapp.domain.recipes.service;
+
+import com.example.recipeapp.domain.recipes.controller.dto.RecipeCreateRequest;
+import com.example.recipeapp.domain.recipes.controller.dto.RecipeResponse;
+import com.example.recipeapp.domain.recipes.controller.dto.RecipeUpdateRequest;
+import com.example.recipeapp.domain.recipes.domain.model.Recipe;
+import com.example.recipeapp.domain.recipes.domain.repository.RecipeRepository;
+import com.example.recipeapp.domain.user.domain.model.User;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RecipeService {
+    private final RecipeRepository recipeRepository;
+
+    // 작성
+    public Long createRecipe(RecipeCreateRequest request, User user) {
+        Recipe recipe = Recipe.builder()
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .category(request.getCategory())
+                .imageUrl(request.getImageUrl())
+                .build();
+
+        return recipeRepository.save(recipe).getId();
+    }
+
+    // 전체 조회
+    @Transactional(readOnly = true)
+    public List<RecipeResponse> getAllRecipes() {
+        return recipeRepository.findAll().stream()
+                .map(RecipeResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    // 단건 조회
+    @Transactional(readOnly = true)
+    public RecipeResponse getRecipeById(Long recipeId) {
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 레시피가 존재하지 않습니다."));
+        return new RecipeResponse(recipe);
+    }
+
+    // 수정
+    public void updateRecipe(Long recipeId, RecipeUpdateRequest request) {
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 레시피가 존재하지 않습니다."));
+
+        recipe.update(request.getTitle(), request.getContent(), request.getCategory(), request.getImageUrl());
+    }
+
+    // 삭제 (soft delete)
+    public void deleteRecipe(Long recipeId) {
+        Recipe recipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 레시피가 존재하지 않습니다."));
+
+        recipeRepository.delete(recipe);
+    }
+}

--- a/src/main/java/com/example/recipeapp/domain/recipes/service/RecipeService.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/service/RecipeService.java
@@ -6,6 +6,8 @@ import com.example.recipeapp.domain.recipes.controller.dto.RecipeUpdateRequest;
 import com.example.recipeapp.domain.recipes.domain.model.Recipe;
 import com.example.recipeapp.domain.recipes.domain.repository.RecipeRepository;
 import com.example.recipeapp.domain.user.domain.model.User;
+import com.example.recipeapp.global.exception.CustomException;
+import com.example.recipeapp.global.exception.ErrorCode;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -45,14 +47,14 @@ public class RecipeService {
     @Transactional(readOnly = true)
     public RecipeResponse getRecipeById(Long recipeId) {
         Recipe recipe = recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 레시피가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
         return new RecipeResponse(recipe);
     }
 
     // 수정
     public void updateRecipe(Long recipeId, RecipeUpdateRequest request) {
         Recipe recipe = recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 레시피가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         recipe.update(request.getTitle(), request.getContent(), request.getCategory(), request.getImageUrl());
     }
@@ -60,7 +62,7 @@ public class RecipeService {
     // 삭제 (soft delete)
     public void deleteRecipe(Long recipeId) {
         Recipe recipe = recipeRepository.findById(recipeId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 레시피가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.RECIPE_NOT_FOUND));
 
         recipeRepository.delete(recipe);
     }

--- a/src/main/java/com/example/recipeapp/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/recipeapp/global/exception/ErrorCode.java
@@ -24,7 +24,11 @@ public enum ErrorCode {
 
 
     // 게시글 관련 에러 정의
-    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다.");
+    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
+
+    // 레시피 관련 에러 정의
+    RECIPE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 레시피입니다."),
+    UNAUTHORIZED_RECIPE_ACCESS(HttpStatus.FORBIDDEN, "해당 레시피에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 📌 개요
레시피 도메인 CRUD 기능 구현, 예외 메시지 ErrorCode + CustomException 방식으로 통일

## ✅ 작업 사항
- [x] 레시피 작성/조회/수정/삭제 API 구현
- [x] 로그인 유저 정보 연동 (`@AuthenticationPrincipal`)
- [x] 레시피, 유저 예외 처리 → CustomException + ErrorCode로 통일
- [x] 기존 `EntityNotFoundException`, `IllegalArgumentException` 제거

## 🔍 리뷰 요청 포인트
- 놓친 부분이나 개선할 부분이 있는지 확인 부탁드립니다.

---