### PR TITLE
fix: 레시피 삭제 시 사용자 정보 누락 오류 해결 - User 주입 추가

### DIFF
--- a/src/main/java/com/example/recipeapp/domain/recipes/controller/RecipeController.java
+++ b/src/main/java/com/example/recipeapp/domain/recipes/controller/RecipeController.java
@@ -81,8 +81,15 @@ public class RecipeController {
 
     // 5. 레시피 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<Void>> deleteRecipe(@PathVariable Long id) {
-        recipeService.deleteRecipe(id);
+    public ResponseEntity<ApiResponse<Void>> deleteRecipe(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AuthUser authUser // 인증된 유저 정보 받기
+    ) {
+        User user = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        recipeService.deleteRecipe(id, user); // user를 넘겨주기
+
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success("레시피가 삭제되었습니다.", null));


### PR DESCRIPTION
## 📌 개요
레시피 삭제 시 인증된 사용자 정보를 서비스에 전달하지 않아 발생한 오류를 해결했습니다.

## ✅ 작업 사항
- [x] `@AuthenticationPrincipal`을 통해 AuthUser 주입  
- [x] UserRepository로 실제 User 객체 조회  
- [x] Service에 `deleteRecipe(id, user)`로 인자 전달

## 🔍 리뷰 요청 포인트
- 삭제 로직 흐름이 자연스럽게 연결되는지 확인 부탁드립니다.
- 인증 유저 확인 및 권한 체크 누락된 부분 없는지 봐주세요.

## 💬 기타 사항
- 관련 이슈: #41 #42 