### PR TITLE
[feat] - 마이페이지 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // query-dsl 5.1.0
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/recipeapp/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/recipeapp/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.example.recipeapp.domain.user.controller;
 
 import com.example.recipeapp.domain.auth.domain.model.AuthUser;
 import com.example.recipeapp.domain.user.controller.dto.request.PasswordChangeRequestDto;
+import com.example.recipeapp.domain.user.controller.dto.response.UserProfileResponseDto;
+import com.example.recipeapp.domain.user.controller.dto.response.UserRecipeResponseDto;
 import com.example.recipeapp.domain.user.controller.dto.response.UserResponseDto;
 import com.example.recipeapp.domain.user.service.UserService;
 import com.example.recipeapp.domain.user.service.dto.ChangePasswordDto;
@@ -42,5 +44,23 @@ public class UserController {
         userService.changePassword(authuser, change);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("비밀번호 변경에 성공했습니다.", null));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserProfileResponseDto>> getCurrentUser(@AuthenticationPrincipal AuthUser authuser){
+
+        UserProfileResponseDto users = userService.getCurrentUser(authuser);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("내 정보를 조회에 성공했습니다.", users));
+    }
+
+    @GetMapping("/me/recipes")
+    public ResponseEntity<ApiResponse<Page<UserRecipeResponseDto>>> getCurrentUserRecipe(
+            @AuthenticationPrincipal AuthUser authuser,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
+
+        Page<UserRecipeResponseDto> users = userService.getCurrentUserRecipe(authuser, pageable);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("내 레시피 목록 조회에 성공했습니다.", users));
     }
 }

--- a/src/main/java/com/example/recipeapp/domain/user/controller/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/controller/dto/response/UserProfileResponseDto.java
@@ -1,0 +1,41 @@
+package com.example.recipeapp.domain.user.controller.dto.response;
+
+import com.example.recipeapp.domain.user.domain.model.User;
+import com.example.recipeapp.domain.user.service.dto.UserProfileDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProfileResponseDto {
+
+    private Long id;
+    private String nickname;
+    private String username;
+    private String email;
+    private int recipeCount;
+    private int totalLikes;
+    private int likedRecipeCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static UserProfileResponseDto from(User user, UserProfileDto userProfileDto){
+        return UserProfileResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .recipeCount(userProfileDto.getRecipeCount())
+                .totalLikes(userProfileDto.getTotalLikes())
+                .likedRecipeCount(userProfileDto.getLikedRecipeCount())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/recipeapp/domain/user/controller/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/controller/dto/response/UserProfileResponseDto.java
@@ -21,7 +21,7 @@ public class UserProfileResponseDto {
     private String email;
     private int recipeCount;
     private int totalLikes;
-    private int likedRecipeCount;
+    private Long likedRecipeCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/example/recipeapp/domain/user/controller/dto/response/UserRecipeResponseDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/controller/dto/response/UserRecipeResponseDto.java
@@ -1,0 +1,36 @@
+package com.example.recipeapp.domain.user.controller.dto.response;
+
+import com.example.recipeapp.domain.recipes.domain.model.RecipeCategory;
+import com.example.recipeapp.domain.user.domain.dto.UserRecipeQueryDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class UserRecipeResponseDto {
+
+    private final Long userId;
+    private final Long recipeId;
+    private final String title;
+    private final RecipeCategory category;
+    private final String imageUrl;
+    private final int likes;
+    private final LocalDateTime createdAt;
+
+    public static UserRecipeResponseDto from(UserRecipeQueryDto queryDto){
+        return UserRecipeResponseDto.builder()
+                .userId(queryDto.getUserId())
+                .recipeId(queryDto.getRecipeId())
+                .title(queryDto.getTitle())
+                .category(queryDto.getCategory())
+                .imageUrl(queryDto.getImageUrl())
+                .likes(queryDto.getLikes())
+                .createdAt(queryDto.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/recipeapp/domain/user/domain/dto/UserProfileQueryDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/dto/UserProfileQueryDto.java
@@ -1,0 +1,14 @@
+package com.example.recipeapp.domain.user.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserProfileQueryDto {
+
+    private int recipeCount;
+    private int totalLikes;
+    private int likedRecipeCount;
+
+}

--- a/src/main/java/com/example/recipeapp/domain/user/domain/dto/UserProfileQueryDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/dto/UserProfileQueryDto.java
@@ -9,6 +9,6 @@ public class UserProfileQueryDto {
 
     private int recipeCount;
     private int totalLikes;
-    private int likedRecipeCount;
+    private Long likedRecipeCount;
 
 }

--- a/src/main/java/com/example/recipeapp/domain/user/domain/dto/UserRecipeQueryDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/dto/UserRecipeQueryDto.java
@@ -1,0 +1,20 @@
+package com.example.recipeapp.domain.user.domain.dto;
+
+import com.example.recipeapp.domain.recipes.domain.model.RecipeCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserRecipeQueryDto {
+
+    private final Long userId;
+    private final Long recipeId;
+    private final String title;
+    private final RecipeCategory category;
+    private final String imageUrl;
+    private final int likes;
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserQueryRepository.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserQueryRepository.java
@@ -1,0 +1,13 @@
+package com.example.recipeapp.domain.user.domain.repository;
+
+import com.example.recipeapp.domain.user.domain.dto.UserProfileQueryDto;
+import com.example.recipeapp.domain.user.domain.dto.UserRecipeQueryDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserQueryRepository {
+
+    UserProfileQueryDto getUserInfo(Long userId);
+
+    Page<UserRecipeQueryDto> findRecipesByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserQueryRepository.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserQueryRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface UserQueryRepository {
-
+    /**
+     *  사용자 관련 조회 전용 쿼리 인터페이스
+     * - 사용자 프로필 요약 정보
+     * - 사용자가 작성한 레시피 목록
+     */
     UserProfileQueryDto getUserInfo(Long userId);
 
     Page<UserRecipeQueryDto> findRecipesByUserId(Long userId, Pageable pageable);

--- a/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserQueryRepositoryImpl.java
@@ -2,7 +2,11 @@ package com.example.recipeapp.domain.user.domain.repository;
 
 import com.example.recipeapp.domain.user.domain.dto.UserProfileQueryDto;
 import com.example.recipeapp.domain.user.domain.dto.UserRecipeQueryDto;
+import com.example.recipeapp.domain.user.domain.model.QUser;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,32 +28,22 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 
     @Override
     public UserProfileQueryDto getUserInfo(Long userId) {
-        // 내가 작성한 레시피 수
-        Long recipeCount = jpaQueryFactory
-                .select(recipe.count())
-                .from(recipe)
-                .where(recipe.user.id.eq(userId))
-                .fetchOne();
-
-        // 내가 작성한 레시피들이 받은 총 좋아요 수
-        Integer totalLikes = jpaQueryFactory
-                .select(recipe.likes.sum().coalesce(0))
-                .from(recipe)
-                .where(recipe.user.id.eq(userId))
-                .fetchOne();
-
-        // 내가 좋아요 한 레시피 수
-        Long likedRecipeCount = jpaQueryFactory
-                .select(likes.count())
+        // 좋아요 누른 레시피 수는 서브쿼리로 분리
+        JPQLQuery<Long> likedRecipeCount = JPAExpressions
+                .select(likes.id.countDistinct())
                 .from(likes)
-                .where(likes.user.id.eq(userId))
-                .fetchOne();
+                .where(likes.user.id.eq(userId));
 
-        return new UserProfileQueryDto(
-                recipeCount != null ? recipeCount.intValue() : 0,
-                totalLikes != null ? totalLikes.intValue() : 0,
-                likedRecipeCount != null ? likedRecipeCount.intValue() : 0
-        );
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        UserProfileQueryDto.class,
+                        recipe.id.countDistinct().intValue(), // 작성한 레시피 수
+                        recipe.likes.sum().coalesce(0).intValue(), // 받은 총 좋아요 수
+                        likedRecipeCount // 좋아요 누른 레시피 수
+                ))
+                .from(recipe)
+                .where(recipe.user.id.eq(userId))
+                .fetchOne();
     }
 
     // 로그인 한 사용자의 레시피 조회(정보 포함)

--- a/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserQueryRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.example.recipeapp.domain.user.domain.repository;
+
+import com.example.recipeapp.domain.user.domain.dto.UserProfileQueryDto;
+import com.example.recipeapp.domain.user.domain.dto.UserRecipeQueryDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.recipeapp.domain.recipes.domain.model.QRecipe.recipe;
+import static com.example.recipeapp.domain.like.domain.model.entity.QLikes.likes;
+import static com.example.recipeapp.domain.user.domain.model.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public UserProfileQueryDto getUserInfo(Long userId) {
+        // 내가 작성한 레시피 수
+        Long recipeCount = jpaQueryFactory
+                .select(recipe.count())
+                .from(recipe)
+                .where(recipe.user.id.eq(userId))
+                .fetchOne();
+
+        // 내가 작성한 레시피들이 받은 총 좋아요 수
+        Integer totalLikes = jpaQueryFactory
+                .select(recipe.likes.sum().coalesce(0))
+                .from(recipe)
+                .where(recipe.user.id.eq(userId))
+                .fetchOne();
+
+        // 내가 좋아요 한 레시피 수
+        Long likedRecipeCount = jpaQueryFactory
+                .select(likes.count())
+                .from(likes)
+                .where(likes.user.id.eq(userId))
+                .fetchOne();
+
+        return new UserProfileQueryDto(
+                recipeCount != null ? recipeCount.intValue() : 0,
+                totalLikes != null ? totalLikes.intValue() : 0,
+                likedRecipeCount != null ? likedRecipeCount.intValue() : 0
+        );
+    }
+
+    // 로그인 한 사용자의 레시피 조회(정보 포함)
+    @Override
+    public Page<UserRecipeQueryDto> findRecipesByUserId(Long userId, Pageable pageable) {
+        List<UserRecipeQueryDto> content = jpaQueryFactory
+                .select(Projections.constructor(
+                        UserRecipeQueryDto.class,
+                        user.id,
+                        recipe.id,
+                        recipe.title,
+                        recipe.category,
+                        recipe.imageUrl,
+                        recipe.likes,
+                        recipe.createdAt
+                ))
+                .from(recipe)
+                .join(recipe.user, user)
+                .where(user.id.eq(userId).and(recipe.isDeleted.eq(false)))
+                .orderBy(recipe.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 페이징 처리
+        Long total = jpaQueryFactory
+                .select(recipe.count())
+                .from(recipe)
+                .where(recipe.user.id.eq(userId).and(recipe.isDeleted.eq(false)))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/recipeapp/domain/user/domain/repository/UserRepository.java
@@ -1,13 +1,16 @@
 package com.example.recipeapp.domain.user.domain.repository;
 
+import com.example.recipeapp.domain.recipes.domain.model.Recipe;
 import com.example.recipeapp.domain.user.domain.model.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserQueryRepository {
 
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);

--- a/src/main/java/com/example/recipeapp/domain/user/service/UserService.java
+++ b/src/main/java/com/example/recipeapp/domain/user/service/UserService.java
@@ -1,12 +1,16 @@
 package com.example.recipeapp.domain.user.service;
 
 import com.example.recipeapp.domain.auth.domain.model.AuthUser;
-import com.example.recipeapp.domain.auth.service.AuthService;
-import com.example.recipeapp.domain.user.controller.dto.request.PasswordChangeRequestDto;
+import com.example.recipeapp.domain.user.controller.dto.response.UserProfileResponseDto;
+import com.example.recipeapp.domain.user.controller.dto.response.UserRecipeResponseDto;
 import com.example.recipeapp.domain.user.controller.dto.response.UserResponseDto;
+import com.example.recipeapp.domain.user.domain.dto.UserProfileQueryDto;
+import com.example.recipeapp.domain.user.domain.dto.UserRecipeQueryDto;
 import com.example.recipeapp.domain.user.domain.model.User;
+import com.example.recipeapp.domain.user.domain.repository.UserQueryRepositoryImpl;
 import com.example.recipeapp.domain.user.domain.repository.UserRepository;
 import com.example.recipeapp.domain.user.service.dto.ChangePasswordDto;
+import com.example.recipeapp.domain.user.service.dto.UserProfileDto;
 import com.example.recipeapp.global.exception.CustomException;
 import com.example.recipeapp.global.exception.ErrorCode;
 import com.example.recipeapp.global.security.PasswordEncoder;
@@ -25,6 +29,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserQueryRepositoryImpl userQueryRepository;
 
     @Transactional(readOnly = true)
     public Page<UserResponseDto> getAllUsers(Pageable pageable) {
@@ -60,6 +65,24 @@ public class UserService {
         String newPassword = passwordEncoder.encode(request.getNewPassword());
 
         user.changePassword(newPassword);
+    }
+
+    public UserProfileResponseDto getCurrentUser(AuthUser authuser) {
+        User user = findByIdAndIsDeletedFalseOrThrow(authuser.getId());
+
+        UserProfileQueryDto queryDto = userQueryRepository.getUserInfo(user.getId());
+
+        UserProfileDto userProfile = UserProfileDto.from(queryDto);
+
+        return UserProfileResponseDto.from(user, userProfile);
+    }
+
+    public Page<UserRecipeResponseDto> getCurrentUserRecipe(AuthUser authuser, Pageable pageable) {
+        User user = findByIdAndIsDeletedFalseOrThrow(authuser.getId());
+
+        Page<UserRecipeQueryDto> queryDto = userQueryRepository.findRecipesByUserId(user.getId(), pageable);
+
+        return queryDto.map(UserRecipeResponseDto::from);
     }
 
     public User findByIdAndIsDeletedFalseOrThrow(Long userId) {

--- a/src/main/java/com/example/recipeapp/domain/user/service/UserService.java
+++ b/src/main/java/com/example/recipeapp/domain/user/service/UserService.java
@@ -67,21 +67,27 @@ public class UserService {
         user.changePassword(newPassword);
     }
 
+    // 현재 로그인한 사용자의 프로필 요약 정보 조회
     public UserProfileResponseDto getCurrentUser(AuthUser authuser) {
         User user = findByIdAndIsDeletedFalseOrThrow(authuser.getId());
 
+        // 사용자 ID로 작성한 레시피 수, 좋아요 받은 수, 좋아요를 한 수를 조회하는 쿼리 실행
         UserProfileQueryDto queryDto = userQueryRepository.getUserInfo(user.getId());
 
+        // 쿼리 결과를 도메인용 DTO로 변환
         UserProfileDto userProfile = UserProfileDto.from(queryDto);
 
         return UserProfileResponseDto.from(user, userProfile);
     }
 
+    //현재 로그인한 사용자가 작성한 레시피 목록 조회 (페이징)
     public Page<UserRecipeResponseDto> getCurrentUserRecipe(AuthUser authuser, Pageable pageable) {
         User user = findByIdAndIsDeletedFalseOrThrow(authuser.getId());
 
+        // 사용자 ID로 작성한 레시피들을 페이징 쿼리로 조회
         Page<UserRecipeQueryDto> queryDto = userQueryRepository.findRecipesByUserId(user.getId(), pageable);
 
+        // 쿼리 결과 DTO들을 응답 DTO로 변환하여 반환
         return queryDto.map(UserRecipeResponseDto::from);
     }
 

--- a/src/main/java/com/example/recipeapp/domain/user/service/dto/UserProfileDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/service/dto/UserProfileDto.java
@@ -10,7 +10,7 @@ public class UserProfileDto {
 
     private int recipeCount;
     private int totalLikes;
-    private int likedRecipeCount;
+    private Long likedRecipeCount;
 
     public static UserProfileDto from(UserProfileQueryDto queryDto){
         return UserProfileDto.builder()

--- a/src/main/java/com/example/recipeapp/domain/user/service/dto/UserProfileDto.java
+++ b/src/main/java/com/example/recipeapp/domain/user/service/dto/UserProfileDto.java
@@ -1,0 +1,22 @@
+package com.example.recipeapp.domain.user.service.dto;
+
+import com.example.recipeapp.domain.user.domain.dto.UserProfileQueryDto;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserProfileDto {
+
+    private int recipeCount;
+    private int totalLikes;
+    private int likedRecipeCount;
+
+    public static UserProfileDto from(UserProfileQueryDto queryDto){
+        return UserProfileDto.builder()
+                .recipeCount(queryDto.getRecipeCount())
+                .totalLikes(queryDto.getTotalLikes())
+                .likedRecipeCount(queryDto.getLikedRecipeCount())
+                .build();
+    }
+}

--- a/src/main/java/com/example/recipeapp/global/config/JPAConfiguration.java
+++ b/src/main/java/com/example/recipeapp/global/config/JPAConfiguration.java
@@ -1,0 +1,19 @@
+package com.example.recipeapp.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JPAConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ spring.jpa.properties.hibernate.use_sql_comments=true
 
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
+jwt.secret.key=${JWT_SECRET_KEY}
+
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 spring.data.redis.host=localhost


### PR DESCRIPTION
## 📌 개요
- 마이페이지: 현재 로그인한 사용자의 프로필 정보 및 작성한 레시피 목록 조회 기능 구현

## ✅ 작업 사항
- [x] QueryDSL 기반 으로 구현 (사용자 프로필 요약 정보 조회)
- [x] 사용자가 작성한 레시피 목록 조회 + 페이징

## 🔍 리뷰 요청 포인트
- QueryDSL 쿼리 성능 및 표현 방식 개선 가능성 검토 부탁드립니다!

## 💬 기타 사항
- 관련 이슈: #32 
---